### PR TITLE
docs: add Exam Hacker and SCUT PDF downloader links

### DIFF
--- a/docs/en/learn/curricular/exam.md
+++ b/docs/en/learn/curricular/exam.md
@@ -17,6 +17,18 @@ TODO: Add exam regulations and guidelines:
 
 [Deferred Exam Application Guide](./deferred_exam.md) is a verified SOP based on two actual applications, covering illness and schedule-conflict evidence, the application form, dual-department approval and three official stamps, receipt delivery, and the next-semester retake enrollment confirmation.
 
+## Exam Preparation Tools
+
+When preparation time is limited and course materials are scattered, [Exam Hacker](https://github.com/Wh1te358/exam-hacker) can turn textbooks, slides, past papers, and notes into a target-score-driven study plan.
+
+It consists of one entry skill and five specialist skills. The workflow triages the materials, target, and available time; compresses knowledge chains; solves complete problems; runs active drills; and replans from mastery evidence. For scanned PDFs, it first checks readability and treats only inspected pages as visual evidence.
+
+## Course PDF Downloader
+
+When a PDF in the SCUT course center has a preview entry but no download button, use the [SCUT Course PDF Downloader](https://github.com/Wh1te358/scut-course-pdf-downloader) Chrome extension. It supports direct PDF URLs and PDF.js preview pages whose addresses contain the original PDF URL.
+
+The current version handles PDFs only, not PPT, PPTX, videos, or course home pages. Its repository README includes installation, testing, and usage instructions.
+
 ## University Physics
 
 Here are _Oplisty_'s **SCUT University Physics Review Notes**:

--- a/docs/learn/curricular/exam.md
+++ b/docs/learn/curricular/exam.md
@@ -22,9 +22,15 @@ TODO: 补充考核规章与应考细则：
 
 ## 期末复习工具
 
-如果复习时间有限、资料零散，可以使用 [Exam Hacker](https://github.com/Wh1te358/skills-by-Wh1te/tree/codex/exam-hacker-skill/exam-hacker) 将教材、课件、真题和笔记整理成目标分数导向的复习方案。
+如果复习时间有限、资料零散，可以使用 [Exam Hacker](https://github.com/Wh1te358/exam-hacker) 将教材、课件、真题和笔记整理成目标分数导向的复习方案。
 
-该 Skill 主要用于评估目标分数、压缩核心概念、逆向拆解真题、梳理综合题知识链，以及生成 A4 复习提纲，可辅助在有限时间内进行优先级判断和策略性取舍。
+它由一个入口 Skill 和五个专用 Skill 组成：先分诊资料、目标和时间，再按需要压缩知识链、完整解题、主动练习，并根据掌握证据重排计划。对于扫描版 PDF，它会先检测可读性；只有实际检查过的页面才会被当作视觉证据。
+
+## 课程 PDF 下载工具
+
+课程中心里的 PDF 课件只有预览入口、没有下载按钮时，可以使用 Chrome 扩展 [SCUT Course PDF Downloader](https://github.com/Wh1te358/scut-course-pdf-downloader)。它支持 PDF 直链，以及地址中包含原始 PDF 的 PDF.js 预览页。
+
+当前版本只处理 PDF，不识别 PPT、PPTX、视频或课程主页。仓库 README 提供了安装、测试和使用步骤。
 
 ## 大学物理
 

--- a/docs/learn/curricular/self_study_science_technology.md
+++ b/docs/learn/curricular/self_study_science_technology.md
@@ -681,7 +681,7 @@ AI帮我们代劳了总结，拆解，模拟出题，但是学习的决策权，
 
 然后打开你电脑上的powershell，确认电脑上有node.js后输入以下命令：
 
-`npx -y skills add Wh1te358/skills-by-Wh1te -g --all`
+`npx -y skills add Wh1te358/exam-hacker -g --all`
 
 这样skill就安装好了。把资料按照上面的格式整理好，按照以下步骤使用：
 
@@ -697,7 +697,7 @@ AI帮我们代劳了总结，拆解，模拟出题，但是学习的决策权，
 
 这个skill为本人开发，并且已经开源在GitHub上，链接如下：
 
-https://github.com/Wh1te358/skills-by-Wh1te/tree/codex/exam-hacker-skill/exam-hacker
+https://github.com/Wh1te358/exam-hacker
 
 如果还有什么想要skill实现的功能，可以在issue中留言，每一条建议我都会认真对待的。
 


### PR DESCRIPTION
## Summary

- replace the branch-specific Exam Hacker URL and installation command with the canonical repository link
- update the Chinese and English exam pages for the revised router-plus-five-specialists workflow
- add the SCUT Course PDF Downloader link and its PDF-only scope in both languages

## GitHub projects

- Exam Hacker: https://github.com/Wh1te358/exam-hacker
- SCUT Course PDF Downloader: https://github.com/Wh1te358/scut-course-pdf-downloader

## Validation

- targeted Prettier check for all three changed Markdown files
- `npm run docs:build`